### PR TITLE
python 3.10 compatibility

### DIFF
--- a/aioschedule/__init__.py
+++ b/aioschedule/__init__.py
@@ -44,7 +44,7 @@ Usage:
 [3] https://adam.herokuapp.com/past/2010/6/30/replace_cron_with_clockwork/
 """
 import asyncio
-import collections
+from collections.abc import Hashable
 import datetime
 import functools
 import logging
@@ -380,7 +380,7 @@ class Job(object):
         :param tags: A unique list of ``Hashable`` tags.
         :return: The invoked job instance
         """
-        if not all(isinstance(tag, collections.Hashable) for tag in tags):
+        if not all(isinstance(tag, Hashable) for tag in tags):
             raise TypeError('Tags must be hashable')
         self.tags.update(tags)
         return self


### PR DESCRIPTION
Tags do not work correctly on python 3.10, since the Hashable abstract base class has been moved to collections.abc module.