### PR TITLE
python 3.11 compatibility

### DIFF
--- a/aioschedule/__init__.py
+++ b/aioschedule/__init__.py
@@ -104,7 +104,7 @@ class Scheduler(object):
 		|                             | futures finish or are cancelled.       |
 		+-----------------------------+----------------------------------------+
         """
-        jobs = [job.run() for job in self.jobs if job.should_run]
+        jobs = [asyncio.create_task(job.run()) for job in self.jobs if job.should_run]
         if not jobs:
             return [], []
 

--- a/aioschedule/__init__.py
+++ b/aioschedule/__init__.py
@@ -104,7 +104,7 @@ class Scheduler(object):
 		|                             | futures finish or are cancelled.       |
 		+-----------------------------+----------------------------------------+
         """
-        jobs = [asyncio.create_task(job.run()) for job in self.jobs if job.should_run]
+        jobs = [job.run() for job in self.jobs if job.should_run]
         if not jobs:
             return [], []
 


### PR DESCRIPTION
Changed in version 3.11: Passing coroutine objects to wait() directly is forbidden.
Need this fix for compatibility